### PR TITLE
Use pinned commits for bun workflow actions

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5
         with:
           bun-version: latest
 

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5
         with:
           bun-version: latest
       - uses: actions/setup-node@v4


### PR DESCRIPTION
Addresses:

https://github.com/The-Best-Codes/discraft-js/security/code-scanning/30
https://github.com/The-Best-Codes/discraft-js/security/code-scanning/31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflows to use a fixed commit for the Bun setup action, ensuring a more consistent environment during formatting and npm publishing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->